### PR TITLE
updating documentation href link in CONTRIBUTING to reflect changes in this DocC catalog instead of referencing one built from one of the dependencies for included modules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ If you are editing documentation inside VSCdde, the default build task will run 
 
 ## Testing changes
 
-To test changes locally you can use [swift-web](https://github.com/adam-fowler/swift-web). Once it is installed run `swift web docs` to run a local HTTP file server with base directory set to the `docs` folder. You can then access the documentation in your web browser from `http://localhost:8001/<version-number>/documentation/hummingbird`.
+To test changes locally you can use [swift-web](https://github.com/adam-fowler/swift-web). Once it is installed run `swift web docs` to run a local HTTP file server with base directory set to the `docs` folder. You can then access the documentation in your web browser from `http://localhost:8001/<version-number>/documentation/index`.
 
 ## Submitting changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,4 +26,4 @@ Changes should be submitting in a PR. In the PR please describe what the changes
 
 ## Deploying changes
 
-Currently v1 documentation is stored on the `main` branch and v2 documentation is stored on the `2.x.x` branch. As soon as a PR is merged into either of these branches the deploy process will begin and you should see your changes live in less than 10 minutes.
+Currently v1 documentation is stored on the `1.x.x` branch and v2 documentation is stored on the `main` branch. As soon as a PR is merged into either of these branches the deploy process will begin and you should see your changes live in less than 10 minutes.


### PR DESCRIPTION
related to my confusion in #33, this updates the HREF link in the CONTRIBUTING.md file to open the 'index', which is content created explicitly from this repositories `Hummingbird.docc` catalog. The reference to `hummingbird` presents the content from the hummingbird project directly, reflecting the content from https://github.com/hummingbird-project/hummingbird-docs/blob/main/Hummingbird.docc/Hummingbird/Hummingbird.md, which was a confusing for seeing new articles and updated content.