### PR TITLE
Todo tutorial formatting

### DIFF
--- a/Hummingbird.docc/Tutorials/Todos/Resources/code/Testing/todos-testing-06.swift
+++ b/Hummingbird.docc/Tutorials/Todos/Resources/code/Testing/todos-testing-06.swift
@@ -23,7 +23,7 @@ struct Todos: AsyncParsableCommand, AppArguments {
 
 /// Arguments extracted from commandline
 protocol AppArguments {
-    var hostname: String { get}
+    var hostname: String { get }
     var port: Int { get }
     var inMemoryTesting: Bool { get }
 }


### PR DESCRIPTION
Fixes a small type for one of the code smalls in the Todo tutorial.