### PR TITLE
Fixed steps in GettingStarted.md

### DIFF
--- a/Hummingbird.docc/Articles/GettingStarted.md
+++ b/Hummingbird.docc/Articles/GettingStarted.md
@@ -17,7 +17,7 @@ Clone the starting template to your local machine:
 
 Run the configure script provided to create a new folder and project inside:
 
-    ../template/configure.sh MyNewProject
+    ./template/configure.sh MyNewProject
 
 Change into the new project directory:
 

--- a/Hummingbird.docc/Articles/GettingStarted.md
+++ b/Hummingbird.docc/Articles/GettingStarted.md
@@ -15,17 +15,15 @@ Clone the starting template to your local machine:
 
     git clone https://github.com/hummingbird-project/template
 
-Create a new directory for your project:
-
-    mkdir MyNewProject
-    cd MyNewProject
-
 Run the configure script provided to create a new folder and project inside:
 
     ../template/configure.sh MyNewProject
 
-This will ask some questions to configure your app. Change into the project folder you 
-create and then, to run your app:
+Change into the new project directory:
+
+    cd MyNewProject
+
+Then run your app:
 
     swift run App
 

--- a/Hummingbird.docc/Articles/GettingStarted.md
+++ b/Hummingbird.docc/Articles/GettingStarted.md
@@ -25,7 +25,7 @@ Run the configure script provided to create a new folder and project inside:
     ../template/configure.sh MyNewProject
 
 This will ask some questions to configure your app. Change into the project folder you 
-creates and then, to run your app:
+create and then, to run your app:
 
     swift run App
 

--- a/Hummingbird.docc/Articles/GettingStarted.md
+++ b/Hummingbird.docc/Articles/GettingStarted.md
@@ -24,7 +24,8 @@ Run the configure script provided to create a new folder and project inside:
 
     ../template/configure.sh MyNewProject
 
-To run your app:
+This will ask some questions to configure your app. Change into the project folder you 
+creates and then, to run your app:
 
     swift run App
 


### PR DESCRIPTION
The wizard creates a subfolder that you need to `cd` into order for the steps to work. 

Without it you hit an issue: 

```zsh
MyNewProject % pwd
/Users/carlton/Projects/Swift/Hummingbird/MyNewProject
MyNewProject % ../template/configure.sh MyNewProject
Configuring your Hummingbird project
Outputting to /Users/carlton/Projects/Swift/Hummingbird/MyNewProject/MyNewProject
Enter your package name: [MyNewProject] > 
Enter your executable name: [App] > 
~/Projects/Swift/Hummingbird/template ~/Projects/Swift/Hummingbird/MyNewProject
~/Projects/Swift/Hummingbird/MyNewProject
MyNewProject % swift run App
error: Could not find Package.swift in this directory or any of its parent directories.
MyNewProject % cd MyNewProject
MyNewProject % swift run App
```