### PR TITLE
Update tutorial for Swift 6

### DIFF
--- a/Hummingbird.docc/Tutorials/Todos/Resources/code/Testing/todos-testing-09.swift
+++ b/Hummingbird.docc/Tutorials/Todos/Resources/code/Testing/todos-testing-09.swift
@@ -17,7 +17,8 @@ final class AppTests: XCTestCase {
         let title: String
         let order: Int?
     }
-    func create(title: String, order: Int? = nil, client: some TestClientProtocol) async throws -> Todo {
+
+    static func create(title: String, order: Int? = nil, client: some TestClientProtocol) async throws -> Todo {
         let request = CreateRequest(title: title, order: order)
         let buffer = try JSONEncoder().encodeAsByteBuffer(request, allocator: ByteBufferAllocator())
         return try await client.execute(uri: "/todos", method: .post, body: buffer) { response in
@@ -31,7 +32,7 @@ final class AppTests: XCTestCase {
     func testCreate() async throws {
         let app = try await buildApplication(TestArguments())
         try await app.test(.router) { client in
-            let todo = try await self.create(title: "My first todo", client: client)
+            let todo = try await Self.create(title: "My first todo", client: client)
             XCTAssertEqual(todo.title, "My first todo")
         }
     }

--- a/Hummingbird.docc/Tutorials/Todos/Resources/code/Testing/todos-testing-10.swift
+++ b/Hummingbird.docc/Tutorials/Todos/Resources/code/Testing/todos-testing-10.swift
@@ -17,7 +17,8 @@ final class AppTests: XCTestCase {
         let title: String
         let order: Int?
     }
-    func create(title: String, order: Int? = nil, client: some TestClientProtocol) async throws -> Todo {
+
+    static func create(title: String, order: Int? = nil, client: some TestClientProtocol) async throws -> Todo {
         let request = CreateRequest(title: title, order: order)
         let buffer = try JSONEncoder().encodeAsByteBuffer(request, allocator: ByteBufferAllocator())
         return try await client.execute(uri: "/todos", method: .post, body: buffer) { response in
@@ -26,7 +27,7 @@ final class AppTests: XCTestCase {
         }
     }
 
-    func get(id: UUID, client: some TestClientProtocol) async throws -> Todo? {
+    static func get(id: UUID, client: some TestClientProtocol) async throws -> Todo? {
         try await client.execute(uri: "/todos/\(id)", method: .get) { response in
             // either the get request returned an 200 status or it didn't return a Todo
             XCTAssert(response.status == .ok || response.body.readableBytes == 0)
@@ -38,7 +39,7 @@ final class AppTests: XCTestCase {
         }
     }
 
-    func list(client: some TestClientProtocol) async throws -> [Todo] {
+    static func list(client: some TestClientProtocol) async throws -> [Todo] {
         try await client.execute(uri: "/todos", method: .get) { response in
             XCTAssertEqual(response.status, .ok)
             return try JSONDecoder().decode([Todo].self, from: response.body)
@@ -50,7 +51,8 @@ final class AppTests: XCTestCase {
         let order: Int?
         let completed: Bool?
     }
-    func patch(id: UUID, title: String? = nil, order: Int? = nil, completed: Bool? = nil, client: some TestClientProtocol) async throws -> Todo? {
+
+    static func patch(id: UUID, title: String? = nil, order: Int? = nil, completed: Bool? = nil, client: some TestClientProtocol) async throws -> Todo? {
         let request = UpdateRequest(title: title, order: order, completed: completed)
         let buffer = try JSONEncoder().encodeAsByteBuffer(request, allocator: ByteBufferAllocator())
         return try await client.execute(uri: "/todos/\(id)", method: .patch, body: buffer) { response in
@@ -63,13 +65,13 @@ final class AppTests: XCTestCase {
         }
     }
 
-    func delete(id: UUID, client: some TestClientProtocol) async throws -> HTTPResponse.Status {
+    static func delete(id: UUID, client: some TestClientProtocol) async throws -> HTTPResponse.Status {
         try await client.execute(uri: "/todos/\(id)", method: .delete) { response in
             response.status
         }
     }
 
-    func deleteAll(client: some TestClientProtocol) async throws -> Void {
+    static func deleteAll(client: some TestClientProtocol) async throws {
         try await client.execute(uri: "/todos", method: .delete) { _ in }
     }
 
@@ -78,7 +80,7 @@ final class AppTests: XCTestCase {
     func testCreate() async throws {
         let app = try await buildApplication(TestArguments())
         try await app.test(.router) { client in
-            let todo = try await self.create(title: "My first todo", client: client)
+            let todo = try await Self.create(title: "My first todo", client: client)
             XCTAssertEqual(todo.title, "My first todo")
         }
     }

--- a/Hummingbird.docc/Tutorials/Todos/Resources/code/Testing/todos-testing-11.swift
+++ b/Hummingbird.docc/Tutorials/Todos/Resources/code/Testing/todos-testing-11.swift
@@ -11,18 +11,18 @@ extension AppTests {
         let app = try await buildApplication(TestArguments())
         try await app.test(.router) { client in
             // create todo
-            let todo = try await self.create(title: "Deliver parcels to James", client: client)
+            let todo = try await Self.create(title: "Deliver parcels to James", client: client)
             // rename it
-            _ = try await self.patch(id: todo.id, title: "Deliver parcels to Claire", client: client)
-            let editedTodo = try await self.get(id: todo.id, client: client)
+            _ = try await Self.patch(id: todo.id, title: "Deliver parcels to Claire", client: client)
+            let editedTodo = try await Self.get(id: todo.id, client: client)
             XCTAssertEqual(editedTodo?.title, "Deliver parcels to Claire")
             // set it to completed
-            _ = try await self.patch(id: todo.id, completed: true, client: client)
-            let editedTodo2 = try await self.get(id: todo.id, client: client)
+            _ = try await Self.patch(id: todo.id, completed: true, client: client)
+            let editedTodo2 = try await Self.get(id: todo.id, client: client)
             XCTAssertEqual(editedTodo2?.completed, true)
             // revert it
-            _ = try await self.patch(id: todo.id, title: "Deliver parcels to James", completed: false, client: client)
-            let editedTodo3 = try await self.get(id: todo.id, client: client)
+            _ = try await Self.patch(id: todo.id, title: "Deliver parcels to James", completed: false, client: client)
+            let editedTodo3 = try await Self.get(id: todo.id, client: client)
             XCTAssertEqual(editedTodo3?.title, "Deliver parcels to James")
             XCTAssertEqual(editedTodo3?.completed, false)
         }

--- a/Hummingbird.docc/Tutorials/Todos/Resources/code/Testing/todos-testing-12.swift
+++ b/Hummingbird.docc/Tutorials/Todos/Resources/code/Testing/todos-testing-12.swift
@@ -11,28 +11,28 @@ extension AppTests {
         let app = try await buildApplication(TestArguments())
         try await app.test(.router) { client in
             // create two todos
-            let todo1 = try await self.create(title: "Wash my hair", client: client)
-            let todo2 = try await self.create(title: "Brush my teeth", client: client)
+            let todo1 = try await Self.create(title: "Wash my hair", client: client)
+            let todo2 = try await Self.create(title: "Brush my teeth", client: client)
             // get first todo
-            let getTodo = try await self.get(id: todo1.id, client: client)
+            let getTodo = try await Self.get(id: todo1.id, client: client)
             XCTAssertEqual(getTodo, todo1)
             // patch second todo
-            let optionalPatchedTodo = try await self.patch(id: todo2.id, completed: true, client: client)
+            let optionalPatchedTodo = try await Self.patch(id: todo2.id, completed: true, client: client)
             let patchedTodo = try XCTUnwrap(optionalPatchedTodo)
             XCTAssertEqual(patchedTodo.completed, true)
             XCTAssertEqual(patchedTodo.title, todo2.title)
             // get all todos and check first todo and patched second todo are in the list
-            let todos = try await self.list(client: client)
+            let todos = try await Self.list(client: client)
             XCTAssertNotNil(todos.firstIndex(of: todo1))
             XCTAssertNotNil(todos.firstIndex(of: patchedTodo))
             // delete a todo and verify it has been deleted
-            let status = try await self.delete(id: todo1.id, client: client)
+            let status = try await Self.delete(id: todo1.id, client: client)
             XCTAssertEqual(status, .ok)
-            let deletedTodo = try await self.get(id: todo1.id, client: client)
+            let deletedTodo = try await Self.get(id: todo1.id, client: client)
             XCTAssertNil(deletedTodo)
             // delete all todos and verify there are none left
-            try await self.deleteAll(client: client)
-            let todos2 = try await self.list(client: client)
+            try await Self.deleteAll(client: client)
+            let todos2 = try await Self.list(client: client)
             XCTAssertEqual(todos2.count, 0)
         }
     }


### PR DESCRIPTION
This fixes the `@Sendable` issue when following this tutorial using `swift-tools-version:6.0`.