### PR TITLE
Get render artifact in build script

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "label": "Build Documentation",
             "detail": "Build docc documentation for Hummingbird",
             "type": "shell",
-            "command": "HUMMINGBIRD_VERSION=2.0 DOCC_HTML_DIR=./scripts/swift-docc-render-artifact/dist ./scripts/build-docc.sh",
+            "command": "HUMMINGBIRD_VERSION=2.0 ./scripts/build-docc.sh",
             "problemMatcher": [],
             "group": "build"
         }

--- a/scripts/build-docc.sh
+++ b/scripts/build-docc.sh
@@ -39,8 +39,8 @@ do
 done
 
 if [ -z "${DOCC_HTML_DIR:-}" ]; then
-    git clone https://github.com/apple/swift-docc-render-artifact "$TEMP_DIR"/swift-docc-render-artifact
-     export DOCC_HTML_DIR="$TEMP_DIR/swift-docc-render-artifact/dist"
+    git submodule update --init --recursive
+    export DOCC_HTML_DIR="./scripts/swift-docc-render-artifact/dist"
 fi
 
 if test "$BUILD_SYMBOLS" == 1; then


### PR DESCRIPTION
Gets render artifact submodule
Remove unnecessary environment variables from VSCode task