### PR TITLE
Split encoding and decoding articles into two articles

### DIFF
--- a/Hummingbird.docc/Articles/RequestContexts.md
+++ b/Hummingbird.docc/Articles/RequestContexts.md
@@ -56,7 +56,7 @@ struct MyRequestContext: RequestContext {
 }
 ```
 
-You can find out more about request decoding and response encoding in <doc:EncodingAndDecoding>.
+You can find out more about request decoding and response encoding in <doc:RequestDecoding> and <doc:ResponseEncoding>.
 
 ## Passing data forward
 

--- a/Hummingbird.docc/Articles/RequestDecoding.md
+++ b/Hummingbird.docc/Articles/RequestDecoding.md
@@ -28,9 +28,9 @@ router.post("user") { request, context -> HTTPResponse.Status in
 ```
 Like the standard `Codable` decode functions `Request.decode(as:context:)` can throw an error if decoding fails. The decode function is also async as the request body is an asynchronous sequence of `ByteBuffers`. We need to collate the request body into one buffer before we can decode it.
 
-## Setting up your encoder/decoder
+## Setting up a custom decoder
 
-If you don't want to use JSON or want to support multiple formats, you need to setup you own `requestDecoder` in a custom request context. Your request decoder needs to conform to the `RequestDecoder` protocol which has one requirement ``RequestDecoder/decode(_:from:context:)``. For instance `Hummingbird` also includes a decoder for URL encoded form data. Below you can see a custom request context setup to use ``URLEncodedFormDecoder`` for request decoding. The router is then initialized with this context. Read <doc:RequestContexts> to find out more about request contexts. 
+If you want to use a different format, a different JSON encoder or want to support multiple formats, you need to setup you own `requestDecoder` in a custom request context. Your request decoder needs to conform to the `RequestDecoder` protocol which has one requirement ``RequestDecoder/decode(_:from:context:)``. For instance `Hummingbird` also includes a decoder for URL encoded form data. Below you can see a custom request context setup to use ``URLEncodedFormDecoder`` for request decoding. The router is then initialized with this context. Read <doc:RequestContexts> to find out more about request contexts. 
 
 ```swift
 struct URLEncodedRequestContext: RequestContext {

--- a/Hummingbird.docc/Articles/RequestDecoding.md
+++ b/Hummingbird.docc/Articles/RequestDecoding.md
@@ -28,6 +28,10 @@ router.post("user") { request, context -> HTTPResponse.Status in
 ```
 Like the standard `Codable` decode functions `Request.decode(as:context:)` can throw an error if decoding fails. The decode function is also async as the request body is an asynchronous sequence of `ByteBuffers`. We need to collate the request body into one buffer before we can decode it.
 
+### Date decoding
+
+As mentioned above the default is to use `JSONDecoder` for decoding `Request` bodies. This default is also set to use ISO 8601 dates in the form `YYYY-MM-DDThh:mm:ssZ`. If you generating requests for a Hummingbird server using `JSONEncoder` you can output ISO 8601 dates by setting `JSONEncoder.dateEncodingStrategy` to `.iso8601`.
+
 ## Setting up a custom decoder
 
 If you want to use a different format, a different JSON encoder or want to support multiple formats, you need to setup you own `requestDecoder` in a custom request context. Your request decoder needs to conform to the `RequestDecoder` protocol which has one requirement ``RequestDecoder/decode(_:from:context:)``. For instance `Hummingbird` also includes a decoder for URL encoded form data. Below you can see a custom request context setup to use ``URLEncodedFormDecoder`` for request decoding. The router is then initialized with this context. Read <doc:RequestContexts> to find out more about request contexts. 

--- a/Hummingbird.docc/Articles/RequestDecoding.md
+++ b/Hummingbird.docc/Articles/RequestDecoding.md
@@ -1,0 +1,67 @@
+# Request Decoding
+
+@Metadata {
+    @PageImage(purpose: icon, source: "logo")
+}
+
+Decoding of Requests with JSON content and other formats.
+
+## Overview
+
+Hummingbird uses `Codable` to decode requests. It defines what decoder to use via the ``RequestContext/requestDecoder`` parameter of your ``RequestContext``. By default this is set to decode JSON, using `JSONDecoder` that comes with Swift Foundation.
+
+Requests are converted to Swift objects using the ``/HummingbirdCore/Request/decode(as:context:)`` method in the following manner.
+
+```swift
+struct User: Decodable {
+    let email: String
+    let firstName: String
+    let surname: String
+}
+router.post("user") { request, context -> HTTPResponse.Status in
+    // decode user from request
+    let user = try await request.decode(as: User.self, context: context)
+    // create user and if ok return `.ok` status
+    try await createUser(user)
+    return .ok
+}
+```
+Like the standard `Codable` decode functions `Request.decode(as:context:)` can throw an error if decoding fails. The decode function is also async as the request body is an asynchronous sequence of `ByteBuffers`. We need to collate the request body into one buffer before we can decode it.
+
+## Setting up your encoder/decoder
+
+If you don't want to use JSON or want to support multiple formats, you need to setup you own `requestDecoder` in a custom request context. Your request decoder needs to conform to the `RequestDecoder` protocol which has one requirement ``RequestDecoder/decode(_:from:context:)``. For instance `Hummingbird` also includes a decoder for URL encoded form data. Below you can see a custom request context setup to use ``URLEncodedFormDecoder`` for request decoding. The router is then initialized with this context. Read <doc:RequestContexts> to find out more about request contexts. 
+
+```swift
+struct URLEncodedRequestContext: RequestContext {
+    var requestDecoder: URLEncodedFormDecoder { .init() }
+    ...
+}
+let router = Router(context: URLEncodedRequestContext.self)
+```
+
+## Decoding based on Request headers
+
+Because the full request is supplied to the `RequestDecoder`. You can make decoding decisions based on headers in the request. In the example below we are decoding using either the `JSONDecoder` or `URLEncodedFormDecoder` based on the "content-type" header.
+
+```swift
+struct MyRequestDecoder: RequestDecoder {
+    func decode<T>(_ type: T.Type, from request: Request, context: some RequestContext) async throws -> T where T : Decodable {
+        guard let header = request.headers[.contentType].first else { throw HTTPError(.badRequest) }
+        guard let mediaType = MediaType(from: header) else { throw HTTPError(.badRequest) }
+        switch mediaType {
+        case .applicationJson:
+            return try await JSONDecoder().decode(type, from: request, context: context)
+        case .applicationUrlEncoded:
+            return try await URLEncodedFormDecoder().decode(type, from: request, context: context)
+        default:
+            throw HTTPError(.badRequest)
+        }
+    }
+}
+```
+
+## See Also 
+
+- ``RequestDecoder``
+- ``RequestContext``

--- a/Hummingbird.docc/Articles/RequestDecoding.md
+++ b/Hummingbird.docc/Articles/RequestDecoding.md
@@ -30,7 +30,7 @@ Like the standard `Codable` decode functions `Request.decode(as:context:)` can t
 
 ### Date decoding
 
-As mentioned above the default is to use `JSONDecoder` for decoding `Request` bodies. This default is also set to use ISO 8601 dates in the form `YYYY-MM-DDThh:mm:ssZ`. If you generating requests for a Hummingbird server using `JSONEncoder` you can output ISO 8601 dates by setting `JSONEncoder.dateEncodingStrategy` to `.iso8601`.
+As mentioned above the default is to use `JSONDecoder` for decoding `Request` bodies. This default is also set to use ISO 8601 dates in the form `YYYY-MM-DDThh:mm:ssZ`. If you are generating requests for a Hummingbird server in a Swift app using `JSONEncoder` you can output ISO 8601 dates by setting `JSONEncoder.dateEncodingStrategy` to `.iso8601`.
 
 ## Setting up a custom decoder
 

--- a/Hummingbird.docc/Articles/ResponseEncoding.md
+++ b/Hummingbird.docc/Articles/ResponseEncoding.md
@@ -28,7 +28,7 @@ router.get("user") { request, _ -> User in
 
 ### Date encoding
 
-As mentioned above the default is to use `JSONEncoder` for encoding `Response` bodies. This default is also set to use ISO 8601 dates in the form `YYYY-MM-DDThh:mm:ssZ`. If you are decoding responses from a Hummingbird server using `JSONDecoder` you can parse dates using ISO 8601 by setting `JSONDecoder.dateDecodingStrategy` to `.iso8601`.
+As mentioned above the default is to use `JSONEncoder` for encoding `Response` bodies. This default is also set to use ISO 8601 dates in the form `YYYY-MM-DDThh:mm:ssZ`. If you are decoding responses from a Hummingbird server in a Swift app using `JSONDecoder` you can parse dates using ISO 8601 by setting `JSONDecoder.dateDecodingStrategy` to `.iso8601`.
 
 ## Setting up a custom encoder
 

--- a/Hummingbird.docc/Articles/ResponseEncoding.md
+++ b/Hummingbird.docc/Articles/ResponseEncoding.md
@@ -1,0 +1,8 @@
+# Response Encoding
+
+@Metadata {
+    @PageImage(purpose: icon, source: "logo")
+}
+
+
+Hummingbird uses `Codable` to decode requests and encode responses. 

--- a/Hummingbird.docc/Articles/ResponseEncoding.md
+++ b/Hummingbird.docc/Articles/ResponseEncoding.md
@@ -4,5 +4,62 @@
     @PageImage(purpose: icon, source: "logo")
 }
 
+Writing Responses using JSON and other formats.
 
-Hummingbird uses `Codable` to decode requests and encode responses. 
+## Overview
+
+Hummingbird uses `Codable` to encode responses. If your router handler returns a type conforming to ``ResponseEncodable`` this will get converted to a ``HummingbirdCore/Response`` using the encoder ``RequestContext/responseEncoder`` parameter of your ``RequestContext``. By default this is set to create a JSON Response using `JSONEncoder` that comes with Swift Foundation.
+
+```swift
+struct User: ResponseEncodable {
+    let email: String
+    let name: String
+}
+
+router.get("user") { request, _ -> User in
+    let user = User(email: "js@email.com", name: "John Smith")
+    return user
+}
+```
+ With the above code and the default JSON encoder you will get a response with header `content-type` set to `application/json; charset=utf-8` and body 
+ ```jsonb
+ {"email":"js@email.com","name":"John Smith"}
+ ```
+
+ ## Setting up a custom encoder
+
+If you want to use a different format, a different JSON encoder or want to support multiple formats, you need to setup you own `responseEncoder` in a custom request context. Your response encoder needs to conform to the `ResponseEncoder` protocol which has one requirement ``ResponseEncoder/encode(_:from:context:)``. For instance `Hummingbird` also includes a encoder for URL encoded form data. Below you can see a custom request context setup to use ``URLEncodedFormEncoder`` for response encoding. The router is then initialized with this context. Read <doc:RequestContexts> to find out more about request contexts. 
+
+```swift
+struct URLEncodedRequestContext: RequestContext {
+    var responseEncoder: URLEncodedFormEncoder { .init() }
+    ...
+}
+let router = Router(context: URLEncodedRequestContext.self)
+```
+
+## Encoding based on Request headers
+
+Because the original request is supplied to the `ResponseEncoder`. You can make encoding decisions based on headers in the request. In the example below we are encoding using either the `JSONEncoder` or `URLEncodedFormEncoder` based on the "accept" header from the request.
+
+```swift
+struct MyResponsEncoder: ResponseEncoder {
+    func encode(_ value: some Encodable, from request: Request, context: some RequestContext) throws -> Response {
+        guard let header = request.headers[values: .accept].first else { throw HTTPError(.badRequest) }
+        guard let mediaType = MediaType(from: header) else { throw HTTPError(.badRequest) }
+        switch mediaType {
+        case .applicationJson:
+            return try JSONEncoder().encode(value, from: request, context: context)
+        case .applicationUrlEncoded:
+            return try URLEncodedFormEncoder().encode(value, from: request, context: context)
+        default:
+            throw HTTPError(.badRequest)
+        }
+    }
+}
+```
+
+## See Also 
+
+- ``ResponseEncoder``
+- ``RequestContext``

--- a/Hummingbird.docc/Articles/ResponseEncoding.md
+++ b/Hummingbird.docc/Articles/ResponseEncoding.md
@@ -26,7 +26,11 @@ router.get("user") { request, _ -> User in
  {"email":"js@email.com","name":"John Smith"}
  ```
 
- ## Setting up a custom encoder
+### Date encoding
+
+As mentioned above the default is to use `JSONEncoder` for encoding `Response` bodies. This default is also set to use ISO 8601 dates in the form `YYYY-MM-DDThh:mm:ssZ`. If you are decoding responses from a Hummingbird server using `JSONDecoder` you can parse dates using ISO 8601 by setting `JSONDecoder.dateDecodingStrategy` to `.iso8601`.
+
+## Setting up a custom encoder
 
 If you want to use a different format, a different JSON encoder or want to support multiple formats, you need to setup you own `responseEncoder` in a custom request context. Your response encoder needs to conform to the `ResponseEncoder` protocol which has one requirement ``ResponseEncoder/encode(_:from:context:)``. For instance `Hummingbird` also includes a encoder for URL encoded form data. Below you can see a custom request context setup to use ``URLEncodedFormEncoder`` for response encoding. The router is then initialized with this context. Read <doc:RequestContexts> to find out more about request contexts. 
 

--- a/Hummingbird.docc/Articles/RouterGuide.md
+++ b/Hummingbird.docc/Articles/RouterGuide.md
@@ -51,7 +51,7 @@ extension String: ResponseGenerator {
 
 In addition to `String` `ByteBuffer`, `HTTPResponseStatus` and `Optional` have also been extended to conform to `ResponseGenerator`.
 
-It is also possible to extend `Codable` objects to generate `Response` by conforming these objects to `ResponseEncodable`. The object will use the response encoder attached to your context to encode these objects. If an object conforms to `ResponseEncodable` then also so do arrays and dictionaries of these objects.
+It is also possible to extend `Codable` objects to generate a `Response` by conforming these objects to ``ResponseEncodable``. The object will use the response encoder attached to your context to encode these objects. If an object conforms to `ResponseEncodable` then also so do arrays and dictionaries of these objects. Read more about generating `Response`s via `Codable` in <doc:ResponseEncoding>.
 
 ### Wildcards
 

--- a/Hummingbird.docc/index.md
+++ b/Hummingbird.docc/index.md
@@ -36,9 +36,9 @@ Below is a list of guides and tutorials to help you get started with building yo
 ### Hummingbird Server
 
 - <doc:RouterGuide>
-- <doc:RequestContexts>
 - <doc:RequestDecoding>
-- <doc:EncodingAndDecoding>
+- <doc:ResponseEncoding>
+- <doc:RequestContexts>
 - <doc:MiddlewareGuide>
 - <doc:ErrorHandling>
 - <doc:LoggingMetricsAndTracing>

--- a/Hummingbird.docc/index.md
+++ b/Hummingbird.docc/index.md
@@ -37,6 +37,7 @@ Below is a list of guides and tutorials to help you get started with building yo
 
 - <doc:RouterGuide>
 - <doc:RequestContexts>
+- <doc:RequestDecoding>
 - <doc:EncodingAndDecoding>
 - <doc:MiddlewareGuide>
 - <doc:ErrorHandling>


### PR DESCRIPTION
Removed EncodingAndDecoding.md
Added RequestDecoding.md and ResponseEncoding.md

Also restructured articles to concentrate on how to use the encoder and decoder in route handlers. Previously the article was upside down telling you how to setup an encoder or decoder before telling you how to use them.