### PR TITLE
Update RequestDecoding.md

### DIFF
--- a/Hummingbird.docc/Articles/RequestDecoding.md
+++ b/Hummingbird.docc/Articles/RequestDecoding.md
@@ -51,7 +51,7 @@ Because the full request is supplied to the `RequestDecoder`. You can make decod
 ```swift
 struct MyRequestDecoder: RequestDecoder {
     func decode<T>(_ type: T.Type, from request: Request, context: some RequestContext) async throws -> T where T : Decodable {
-        guard let header = request.headers[.contentType].first else { throw HTTPError(.badRequest) }
+        guard let header = request.headers[.contentType] else { throw HTTPError(.badRequest) }
         guard let mediaType = MediaType(from: header) else { throw HTTPError(.badRequest) }
         switch mediaType {
         case .applicationJson:


### PR DESCRIPTION
Removes unnecessary `first` when retrieving `.contentType` header