### PR TITLE
Typo, grammar, and wording corrections and refinement for the swift-mustache content of the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Hummingbird documentation is generated using Apple's docc documentation compiler
 ```
 HUMMINGBIRD_VERSION=2.0 ./scripts/build-docc.sh
 ```
-If you are editing documentation inside VSCdde, the default build task will run the code above.
+If you are editing documentation inside VS Code, the default build task runs the code above.
 
 ## Testing changes
 
@@ -22,7 +22,7 @@ To test changes locally you can use [swift-web](https://github.com/adam-fowler/s
 
 ## Submitting changes
 
-Changes should be submitting in a PR. In the PR please describe what the changes are and why they are needed. Also try to keep PRs to a minimal number of changes as possible. It is a lot easier to review multiple PRs of smaller changes than one big PR.
+Changes should be submitted in a PR. In the PR please describe what the changes are and why they are needed. Also try to keep PRs to a minimal number of changes as possible. It is a lot easier to review multiple PRs of smaller changes than one big PR.
 
 ## Deploying changes
 

--- a/Hummingbird.docc/Mustache/Mustache.md
+++ b/Hummingbird.docc/Mustache/Mustache.md
@@ -8,9 +8,9 @@ Mustache template engine.
 
 ## Overview
 
-Mustache is a "logic-less" templating language commonly used in web and mobile platforms. You can find out more about Mustache [here](http://mustache.github.io/mustache.5.html).
+Mustache is a "logic-less" templating language commonly used in web and mobile platforms. You can find out more about it from the [mustache manual](http://mustache.github.io/mustache.5.html).
 
-While swift-mustache has been designed to be used with the Hummingbird server framework it has no dependencies and can be used as a standalone library.
+While swift-mustache has been designed to be used with the Hummingbird server framework, it has no dependencies and can be used as a standalone library.
 
 ## Usage
 
@@ -18,13 +18,13 @@ Load your templates from the filesystem
 ```swift
 let library = MustacheLibrary("folder/my/templates/are/in")
 ```
-This will look for all the files with the extension ".mustache" in the specified folder and subfolders and attempt to load them. Each file is registed with the name of the file (with subfolder, if inside a subfolder) minus the "mustache" extension.
+This will look for all the files with the extension `.mustache` in the specified folder and subfolders and attempt to load them. Each file is registered with the name of the file (with subfolder, if inside a subfolder) minus the `.mustache` extension.
 
-Render an object with a template 
+The following code shows how to render an object with a template:
 ```swift
 let output = library.render(object, withTemplate: "myTemplate")
 ```
-`Mustache` treats an object as a set of key/value pairs when rendering and will render both dictionaries and objects via `Mirror` reflection.
+`Mustache` treats an object as a set of key/value pairs when rendering and renders both dictionaries and objects via `Mirror` reflection.
 
 ## Support
 

--- a/Hummingbird.docc/Mustache/MustacheSyntax.md
+++ b/Hummingbird.docc/Mustache/MustacheSyntax.md
@@ -8,11 +8,11 @@ Overview of Mustache Syntax
 
 ## Overview
 
-Mustache is a "logic-less" templating engine. The core language has no flow control statements. Instead it has tags that can be replaced with a value, nothing or a series of values. Below we document all the standard tags
+Mustache is a "logic-less" templating engine. The core language has no flow control statements. Instead it has tags that can be replaced with a value, nothing, or a series of values. This article documents the standard mustache tags.
 
-## Context
+### Context
 
-Mustache renders a template with a context stack. A context is a list of key/value pairs. These can be represented by either a `Dictionary` or the reflection information from `Mirror`. For example the following two objects will render in the same way
+Mustache renders a template with a context stack. A context is a list of key/value pairs. These can be represented by either a `Dictionary` or the reflection information that `Mirror` provides. For example, the following two objects render in the same way
 ```swift
 let object = ["name": "John Smith", "age": 68]
 ```
@@ -24,27 +24,33 @@ struct Person {
 let object = Person(name: "John Smith", age: 68)
 ```
 
-Initially the stack will consist of the root context object you want to render. When we enter a section tag we push the associated value onto the context stack and when we leave the section we pop that value back off the stack.
+Initially the stack consists of the root context object to render. When the template enters a section tag, mustache pushes the associated value onto the context stack. When the template leaves the section, it pops that value back off the stack.
 
-## Tags
+### Tags
 
-All tags are surrounded by a double curly bracket `{{}}`. When a tag has a reference to a key, the key will be searched for from the context at the top of the context stack and the associated value will be output. If the key cannot be found then the next context down will be searched and so on until either a key is found or we have reached the bottom of the stack. If no key is found the output for that value is `nil`. 
+Surround all tags with a double curly bracket `{{}}`.
+When a tag has a reference to a key, mustache searches for the key from the context at the top of the context stack to return the associated value.
+If the key can't be found in the current context, then mustache recursively searches the next context down until either a key is found or it reaches the bottom of the stack.
+If no key is found the output is `nil`, which renders as an empty string.
 
-A tag can be used to reference a child value from the associated value of a key by using dot notation in a similar manner to Swift. eg in `{{main.sub}}` the first context is searched for the  `main` key. If a value is found, that value is used as a context and the key `sub` is used to search within that context and so on. 
+Use dot notation to reference the child of an associated value of a key, similar to Swift.
+For example, in the tag `{{main.sub}}`, mustache searches the first context for the key `main`. If found, is uses that value for context and searches `main` for the key `sub`.
 
-If you want to only search for values in the context at the top of the stack then prefix the variable name with a "." eg `{{.key}}`
+To constrain mustache to search for values in the context at the top of the stack, prefix the variable name with the period (`.`), for example: `{{.key}}`.
 
-## Tag types
+Use `{{.}}` to reference only the top of the stack, which can be useful if you present a template with a list.
 
-- `{{key}}`: Render value associated with `key` as text. By default this is HTML escaped. A `nil` value is rendered as an empty string.
-- `{{{name}}}`: Acts the same as `{{name}}` except the resultant text is not HTML escaped. You can also use `{{&name}}` to avoid HTML escaping.
-- `{{#section}}`: Section render blocks either render text once or multiple times depending on the value of the key in the current context. A section begins with `{{#section}}` and end with `{{/section}}`. If the key represents a `Bool` value it will only render if it is true. If the key represents an `Optional` it will only render if the object is non-nil. If the key represents an `Array` it will then render the internals of the section multiple times, once for each element of the `Array`. Otherwise it will render with the selected value pushed onto the top of the context stack.
-- `{{^section}}`: An inverted section does the opposite of a section. If the key represents a `Bool` value it will render if it is false. If the key represents an `Optional` it will render if it is `nil`. If the key represents a `Array` it will render if the `Array` is empty.
-- `{{! comment }}`: This is a comment tag and is ignored.
-- `{{>partial}}`: A partial tag renders another mustache file, with the current context stack. In Swift Mustache partial tags only work for templates that are a part of a library and the tag is the name of the referenced file without the ".mustache" extension.
-- `{{*>dynamic}}`: Is a partial that can be dynamically loaded.
-- `{{<parent}}`: A parent is similar to a partial but allows for the user to override sections of the include file. A parent tag is a section tag so needs to end with a `{{/parent}}` tag.
-- `{{$}}`: A block is a section of a parent that can be overriden. If this is found inside a parent section then it is the text that will replace the overriden block. 
-- `{{=<% %>=}}`: The set delimiter tag allows you to change from using the double curly brackets as tag delimiters. In the example the delimiters have been changed to `<% %>` but you can change them to whatever you like.
+### Tag types
+
+- `{{key}}`: Render the value associated with `key` as text. By default this is HTML escaped. Mustache renders a `nil` value as an empty string.
+- `{{{name}}}`: Acts the same as `{{name}}`, except the resulting text is not HTML escaped. You can also use `{{&name}}` to avoid HTML escaping.
+- `{{#section}}`: The `#` character represents a section block that either renders text once or multiple times depending on the value of the key in the current context. A section begins with `{{#section}}` and ends with `{{/section}}`. If the key represents a Boolean value, it only renders if true. If the key represents an `Optional` it renders if the object is non-nil. If the key represents an `Array` it renders the internals of the section multiple times, once for each element of the `Array`. Otherwise it renders with the selected value pushed onto the top of the context stack. See <doc:MustacheFeatures#Rendering-sections> for more information.
+- `{{^section}}`: An inverted section (`^`) does the opposite of a section. If the key represents a Boolean value, it renders if the value is false. If the key represents an `Optional` it renders if it is `nil`. If the key represents a `Array` it renders if the `Array` is empty.
+- `{{! comment }}`: `!` indicates a comment tag, which is ignored.
+- `{{>partial}}`: A partial tag (`>`) renders another mustache file, with the current context stack. In Swift Mustache, partial tags only work for templates that are a part of a library, and the tag represents the  name of the referenced template without the ".mustache" extension. See <doc:MustacheFeatures#Partial-templates> for more information.
+- `{{*>dynamic}}`: Is a partial that mustache loads dynamically.
+- `{{<parent}}`: A parent (`<`) is similar to a partial, but allows for the user to override sections of the included file. A parent tag is a section tag, and needs to end with a `{{/parent}}` tag. See <doc:MustacheFeatures#Template-inheritance-and-parents> for more information.
+- `{{$}}`: The `$` represents a block that is a section of a parent template to override. If this is found inside a parent section, then it is the text that mustache replaces from the overriden block. 
+- `{{=<% %>=}}`: The set delimiter (`=`) tag allows you to change from using the double curly brackets as tag delimiters. In the example the delimiters have been changed to `<% %>`, but you can change them to whatever you like.
 
 You can find out more about the standard Mustache tags in the [Mustache Manual](https://mustache.github.io/mustache.5.html).


### PR DESCRIPTION
My core goal was learning how to use partials (not inheritance) with swift-mustache templates, which was a bit buried - but as I was iterating through the content I spotted and wanted to fix various other wording bits as I saw them, so this grew quite a bit.

I apologize for the size, doing many smaller PRs would be my preference but I'm also a bit administratively constrained so a single larger update is a bit easier to wrangle.