### PR TITLE
Additional docs for RequestContext

### DIFF
--- a/Hummingbird.docc/Articles/RequestContexts.md
+++ b/Hummingbird.docc/Articles/RequestContexts.md
@@ -142,7 +142,20 @@ router.group("/todos", context: MyNewRequestContext.self)
     .get(use: listTodos)
 ```
 
-Transforming the `RequestContext` is a powerful way of enforcing compile-time guarantees that requests adhere to certain requirements. And by expressing these requirements as protocol conformances, you can compose these properties and flexibly express those requirements.
+Transforming the `RequestContext` is a powerful way of enforcing compile-time guarantees that requests adhere to certain requirements. And by expressing these requirements as protocol conformances, you can compose these properties and flexibly express those requirements. 
+
+An example of using a `ChildRequestContext` would be to unwrap an optional authentication identity. Every route that uses that child request context with the unwrapped identity now knows for sure you have an authenticated identity.
+
+```swift
+struct MyAuthenticatedRequestContext: ChildRequestContext {
+    typealias ParentContext = MyRequestContext
+    init(context: ParentContext) throws {
+        self.coreContext = context.coreContext
+        self.identity = try context.requireIdentity()
+        ...
+    }
+}
+```
 
 ## Authentication Middleware
 

--- a/Hummingbird.docc/Articles/RequestContexts.md
+++ b/Hummingbird.docc/Articles/RequestContexts.md
@@ -136,7 +136,7 @@ struct MyNewRequestContext: ChildRequestContext {
 Once you have defined how to perform the transform from your original `RequestContext` the conversion is added as follows
 
 ```swift
-let app = Application(context: MyRequestContext.self)
+let router = Router(context: MyRequestContext.self)
 router.group("/todos", context: MyNewRequestContext.self)
     .put(use: createTodo)
     .get(use: listTodos)

--- a/Hummingbird.docc/Articles/RouterGuide.md
+++ b/Hummingbird.docc/Articles/RouterGuide.md
@@ -172,28 +172,6 @@ router.group("/todos")
     .delete("{id}", deleteTodo)
 ```
 
-### RequestContext transformation
-
-The `RequestContext` can be transformed for the routes in a route group. The `RequestContext` you are converting to needs to conform to ``ChildRequestContext``. This requires a parent context ie the `RequestContext` you are converting from and a ``ChildRequestContext/init(context:)`` function to perform the conversion.
-
-```swift
-struct MyNewRequestContext: ChildRequestContext {
-    typealias ParentContext = MyRequestContext
-    init(context: ParentContext) throws {
-        self.coreContext = context.coreContext
-        ...
-    }
-}
-```
-Once you have defined how to perform the transform from your original `RequestContext` the conversion is added as follows
-
-```swift
-let app = Application(context: MyRequestContext.self)
-router.group("/todos", context: MyNewRequestContext.self)
-    .put(use: createTodo)
-    .get(use: listTodos)
-```
-
 ### Route Collections
 
 A ``RouteCollection`` is a collection of routes and middleware that can be added to a `Router` in one go. It has the same API as `RouterGroup`, so can have groups internal to the collection to allow for Middleware to applied to only sub-sections of the `RouteCollection`. 


### PR DESCRIPTION
When editing ChildRequestContext section I moved it from the router guide to the request context guide which made more sense